### PR TITLE
Add 46elks sms provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,25 @@ new NotifmeSdk({
 ```
 
 </p></details>
+
+<details><summary>46elks</summary><p>
+
+```javascript
+new NotifmeSdk({
+  channels: {
+    sms: {
+      providers: [{
+        type: '46elks',
+        apiUsername: 'xxxxx',
+        apiPassword: 'xxxxx'
+      }]
+    }
+  }
+})
+```
+
+</p></details>
+
 <details><summary>Logger (for development)</summary><p>
 
 ```javascript

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,6 +286,20 @@ notifmeSdk
   }
 })</pre></div>
                   <p></p></details>
+                  <details><summary>46elks</summary><p>
+                  </p>
+<div class="highlight highlight-source-js"><pre><span class="pl-k">new</span> <span class="pl-en">NotifmeSdk</span>({
+  channels<span class="pl-k">:</span> {
+    sms<span class="pl-k">:</span> {
+      providers<span class="pl-k">:</span> [{
+        type<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">'</span>46elks<span class="pl-pds">'</span></span>,
+        apiUsername<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">'</span>xxxxx<span class="pl-pds">'</span></span>,
+        apiPassword<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">'</span>xxxxx<span class="pl-pds">'</span></span>
+      }]
+    }
+  }
+})</pre></div>
+                  <p></p></details>
                   <details><summary>Logger (for development)</summary><p>
                   </p>
 <div class="highlight highlight-source-js"><pre><span class="pl-k">new</span> <span class="pl-en">NotifmeSdk</span>({

--- a/src/models/provider-sms.js
+++ b/src/models/provider-sms.js
@@ -11,4 +11,8 @@ export type SmsProviderType = {
   type: 'twilio',
   accountSid: string,
   authToken: string
+} | {
+  type: '46elks',
+  apiUsername: string,
+  apiPassword: string
 }

--- a/src/providers/sms/46elks.js
+++ b/src/providers/sms/46elks.js
@@ -1,0 +1,34 @@
+/* @flow */
+import Request from 'request-promise-native'
+// Types
+import type {SmsRequestType} from '../../models/notification-request'
+
+export default class Sms46elksProvider {
+  id: string
+  credentials: Object
+
+  constructor (config: Object) {
+    this.id = 'sms-46elks-provider'
+    this.credentials = {
+      username: config.apiUsername,
+      password: config.apiPassword
+    }
+  }
+
+  async send (request: SmsRequestType): Promise<string> {
+    const {username, password} = this.credentials
+    try {
+      const result = await Request
+        .post('https://api.46elks.com/a1/sms')
+        .auth(username, password)
+        .form({
+          from: request.from,
+          to: request.to,
+          message: (request: any).text
+        })
+      return JSON.parse(result)['id']
+    } catch (error) {
+      throw new Error(error.message)
+    }
+  }
+}

--- a/src/providers/sms/index.js
+++ b/src/providers/sms/index.js
@@ -3,6 +3,7 @@ import SmsLoggerProvider from './logger'
 import SmsNexmoProvider from './nexmo'
 import SmsNotificationCatcherProvider from './notificationCatcher'
 import SmsTwilioProvider from './twilio'
+import Sms46elksProvider from './46elks'
 // Types
 import type {SmsRequestType} from '../../models/notification-request'
 
@@ -27,6 +28,9 @@ export default class SmsProvider {
         break
       case 'twilio':
         this.provider = new SmsTwilioProvider(config)
+        break
+      case '46elks':
+        this.provider = new Sms46elksProvider(config)
         break
       default:
         throw new Error(`Unknown sms provider "${type}".`)


### PR DESCRIPTION
Hi! Mac here from [46elks](https://www.46elks.com) :)

Someone mentioned notifme in [this](https://www.facebook.com/groups/utvecklare.stockholm/permalink/1442236412492093/) post in the Facebook group Kodapor looking for Swedish SMS providers to support it. Well, we're a Swedish SMS (and MMS, and voice calls) provider so why not? I've tried to follow the existing code style, linted, updated the docs etc. and have done some basic testing.

Let me know if there's anything you want fixed or feel free to do whatever you please with the patch.