### PR TITLE
added PLIVO as a SMS service provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib
 yarn-error.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -294,6 +294,23 @@ new NotifmeSdk({
 
 </p></details>
 
+<details><summary>Plivo</summary><p>
+
+```javascript
+new NotifmeSdk({
+  channels: {
+    sms: {
+      providers: [{
+        type: 'Plivo',
+        authId: 'xxxxx',
+        authToken: 'xxxxx'
+      }]
+    }
+  }
+})
+```
+</p></details>
+
 <details><summary>Logger (for development)</summary><p>
 
 ```javascript

--- a/src/models/provider-sms.js
+++ b/src/models/provider-sms.js
@@ -15,4 +15,8 @@ export type SmsProviderType = {
   type: '46elks',
   apiUsername: string,
   apiPassword: string
+} | {
+  type: 'plivo',
+  authId: string,
+  authToken: string
 }

--- a/src/providers/sms/index.js
+++ b/src/providers/sms/index.js
@@ -4,6 +4,7 @@ import SmsNexmoProvider from './nexmo'
 import SmsNotificationCatcherProvider from './notificationCatcher'
 import SmsTwilioProvider from './twilio'
 import Sms46elksProvider from './46elks'
+import SmsPlivoProvider from './plivo'
 // Types
 import type {SmsRequestType} from '../../models/notification-request'
 
@@ -31,6 +32,9 @@ export default class SmsProvider {
         break
       case '46elks':
         this.provider = new Sms46elksProvider(config)
+        break
+      case 'plivo':
+        this.provider = new SmsPlivoProvider(config)
         break
       default:
         throw new Error(`Unknown sms provider "${type}".`)

--- a/src/providers/sms/plivo.js
+++ b/src/providers/sms/plivo.js
@@ -1,0 +1,37 @@
+/* @flow */
+import Request from 'request-promise-native'
+// Types
+import type {SmsRequestType} from '../../models/notification-request'
+
+export default class SmsPlivoProvider {
+  id: string
+  credentials: Object
+
+  constructor (config: Object) {
+    this.id = 'sms-plivo-provider'
+    this.credentials = {authId: config.authId, authToken: config.authToken}
+  }
+
+  async send (request: SmsRequestType): Promise<string> {
+    const {authId, authToken} = this.credentials
+    try {
+      const result = await Request
+        .post(`https://api.plivo.com/v1/Account/${authId}/Message/`)
+        .auth(authId, authToken,false)
+        .json({
+          'src': request.from,
+          'dst': request.to,
+          'text': (request: any).text
+        })
+      return result.message_uuid[0]
+    } catch (error) {
+      let errorMessage;
+      if (error.statusCode == 401) {
+        errorMessage = error.error;
+      }else{
+        errorMessage = error.error.error;
+      }
+      throw new Error(errorMessage)
+    }
+  }
+}


### PR DESCRIPTION
Hey, this is Abhishek from Plivo . We saw this cool npm package and thought of adding Plivo as a SMS provider in this module . Please find the commit details mentioned below as well review the commits :- 

- [src/providers/sms/plivo.js](https://github.com/notifme/notifme-sdk/compare/master...plivo-dev:Add-Plivo-SMS-Provider?expand=1#diff-1c96dd72b8e20c435b6412f9b147de95) : added `SmsPlivoProvider` module for sending SMS via PLIVO
- [src/models/provider-sms.js](https://github.com/notifme/notifme-sdk/compare/master...plivo-dev:Add-Plivo-SMS-Provider?expand=1#diff-1a09658bbf25ea33eeadbdbd8d4a9500) : added plivo in sms-provider model
- [src/providers/sms/index.js](https://github.com/notifme/notifme-sdk/compare/master...plivo-dev:Add-Plivo-SMS-Provider?expand=1#diff-949038133c55af179460b3ca27a97102) : imported `SmsPlivoProvider` and enabled it to be used by giving `plivo` as the provider name 
- [README.md](https://github.com/notifme/notifme-sdk/compare/master...plivo-dev:Add-Plivo-SMS-Provider?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8) :  added documentation of initializing sdk with plivo.
- [.gitignore](https://github.com/notifme/notifme-sdk/compare/master...plivo-dev:Add-Plivo-SMS-Provider?expand=1#diff-a084b794bc0759e7a6b77810e01874f2) ignored automatically generated macbook files (`.DS_Store`)
