### PR TITLE
add support for sendgrid using nodemailer and nodemailer-sendgrid-tra…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 lib
 yarn-error.log
 .DS_Store
+*.vscode*

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-fetch": "1.7.2",
     "node-pushnotifications": "1.0.18",
     "nodemailer": "4.0.1",
+    "nodemailer-sendgrid-transport": "0.2.0",
     "web-push": "3.2.2",
     "winston": "2.3.1"
   },

--- a/src/providers/email/index.js
+++ b/src/providers/email/index.js
@@ -2,6 +2,7 @@
 import EmailLoggerProvider from './logger'
 import EmailNotificationCatcherProvider from './notificationCatcher'
 import EmailSendmailProvider from './sendmail'
+import EmailSendGridProvider from './sendgrid'
 import EmailSmtpProvider from './smtp'
 // Types
 import type {EmailRequestType} from '../../models/notification-request'
@@ -27,6 +28,9 @@ export default class EmailProvider {
         break
       case 'smtp':
         this.provider = new EmailSmtpProvider(config)
+        break
+      case 'sendgrid':
+        this.provider = new EmailSendGridProvider(config)
         break
       default:
         throw new Error(`Unknown email provider "${type}".`)

--- a/src/providers/email/sendgrid.js
+++ b/src/providers/email/sendgrid.js
@@ -1,0 +1,25 @@
+/* @flow */
+import nodemailer from "nodemailer";
+import sgTransport from "nodemailer-sendgrid-transport";
+// Types
+import type { EmailRequestType } from "../../models/notification-request";
+
+export default class EmailSendGridProvider {
+  id: string;
+  transporter: Object;
+
+  constructor(config: Object) {
+    this.id = "email-sendgrid-provider";
+    const sgOptions = {
+      auth: {
+        api_key: config.apiKey
+      }
+    };
+    this.transporter = nodemailer.createTransport(sgTransport(sgOptions));
+  }
+
+  async send(request: EmailRequestType): Promise<string> {
+    const result = await this.transporter.sendMail(request);
+    return result.messageId;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2354,7 +2354,7 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash@^3.10.1:
+"lodash@^3.0.1 || ^2.0.0", lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -2439,7 +2439,7 @@ mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-mime@^1.3.4:
+mime@^1.2.9, mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
@@ -2569,6 +2569,12 @@ nodemailer-fetch@1.3.0:
 nodemailer-fetch@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz#79c4908a1c0f5f375b73fe888da9828f6dc963a4"
+
+nodemailer-sendgrid-transport@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz#a516593bfe3d1f278cfe17060e1db23658a8f4fc"
+  dependencies:
+    sendgrid "^1.8.0"
 
 nodemailer-shared@1.0.4:
   version "1.0.4"
@@ -3067,7 +3073,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.81.0:
+request@^2.60.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3190,6 +3196,15 @@ send@0.13.2:
     range-parser "~1.0.3"
     statuses "~1.2.1"
 
+sendgrid@^1.8.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/sendgrid/-/sendgrid-1.9.2.tgz#d407e6a206b0a2a6964246dd9c0641c10bf02f19"
+  dependencies:
+    lodash "^3.0.1 || ^2.0.0"
+    mime "^1.2.9"
+    request "^2.60.0"
+    smtpapi "^1.2.0"
+
 serve-static@~1.10.2:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.10.3.tgz#ce5a6ecd3101fed5ec09827dac22a9c29bfb0535"
@@ -3242,6 +3257,10 @@ smtp-server@1.16.1:
   dependencies:
     ipv6-normalize "^1.0.1"
     nodemailer-shared "^1.1.0"
+
+smtpapi@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/smtpapi/-/smtpapi-1.3.1.tgz#187429eb4ed27df4a3cffd23f0e0245cdfe687d4"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
Address #7 
This adds support for sendgrid. It was tested manually and works for basic message sending.

It makes use of this: https://sendgrid.com/blog/sending-email-nodemailer-sendgrid/ 

This was the quickest to implement... it is not the ideal method as it adds 1.1mb raw (according to vscode import cost) and sendgrid no longer supports https://github.com/sendgrid/nodemailer-sendgrid-transport.

An ideal method would use `node-fetch` and this API: https://sendgrid.com/docs/API_Reference/api_v3.html