### PR TITLE
feat: add support for the full slack webhook payload

### DIFF
--- a/src/models/notification-request.js
+++ b/src/models/notification-request.js
@@ -130,7 +130,36 @@ export type WebpushRequestType = RequestMetadataType & {
 }
 
 export type SlackRequestType = RequestMetadataType & {
-  text: string
+  text: string,
+  unfurl_links?: boolean,
+  attachments?: {
+    fallback?: string,
+    color?: string,
+    pretext?: string,
+    author_name?: string,
+    author_link?: string,
+    author_icon?: string,
+    title?: string,
+    title_link?: string,
+    text?: string,
+    fields?: {
+      title?: string,
+      value?: string,
+      short?: boolean
+    }[],
+    actions?: {
+      type: string,
+      text: string,
+      url: string,
+      style?: string
+    }[],
+    image_url?: string,
+    thumb_url?: string,
+    footer?: string,
+    footer_icon?: string,
+    ts?: number,
+  }[],
+  webhookUrl?: string
 }
 
 export type RequestType = EmailRequestType | PushRequestType | SmsRequestType | VoiceRequestType | WebpushRequestType | SlackRequestType

--- a/src/models/provider-slack.js
+++ b/src/models/provider-slack.js
@@ -10,5 +10,5 @@ export type SlackProviderType = {
   send: (SlackRequestType) => Promise<string>
 } | {
   type: 'webhook',
-  webhookUrl: string
+  webhookUrl?: string
 }

--- a/src/providers/slack/slack.js
+++ b/src/providers/slack/slack.js
@@ -12,20 +12,21 @@ export default class SlackProvider {
   }
 
   async send (request: SlackRequestType): Promise<string> {
-    const body = JSON.stringify({
-      text: request.text
-    })
+    const webhookUrl = request.webhookUrl || this.webhookUrl
+
+    delete request.webhookUrl
+    const body = JSON.stringify(request)
     const apiRequest = {
       method: 'POST',
       body
     }
 
-    const response = await fetch(this.webhookUrl, apiRequest)
+    const response = await fetch(webhookUrl, apiRequest)
 
-    const responseText = await response.text()
     if (response.ok) {
       return '' // Slack only returns 'ok'
     } else {
+      const responseText = await response.text()
       throw new Error(`${response.status} - ${responseText}`)
     }
   }


### PR DESCRIPTION
The initial slack provider had 2 limitations:
1. it allowed sending only the message, without all the customization slack allows.
2. it allowed sending to a unique/global webhook. There are 2 scenarios for `notifme-sdk`: 
  - used to send global notifications (like application errors, logs, events). In this case a single webhook in the config is enough.
  - used by the users of an app - they integrate the app with slack and the app sends _them_ messages. In this case the webhook urls are more like the `to` emails in the email provider - there should be a single slack provider set up but able to send to various recipients. This case wasn't covered by the existing slack provider but it is with these changes.

I made the `webhookUrl` in the slack config optional. Either the config, or the `send` payload must specify a webhookUrl.
To be honest, I would like webhookUrl in the payload to be either a string or an array eventually, so we can send to more hooks at once, just like we can send to more `cc` or `bcc` recipients in emails. The difference would be that `notifme-sdk` would have to fire multiple `fetch` requests in this case.