### PR TITLE
Custom Notification Catcher connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ notifmeSdk
 
 ![Getting started SMS catcher](https://notifme.github.io/notifme-sdk/img/getting-started-sms-catcher.png)
 
+#### Custom connection settings
+
+If you have the Notification Catcher running on a custom port, domain, or you need to change any other connection setting, set the environment variable `NOTIFME_CATCHER_OPTIONS` with your [custom connection smtp url](https://nodemailer.com/smtp/).
+
+```shell
+$ # Example
+$ NOTIFME_CATCHER_OPTIONS=smtp://127.0.0.1:3025?ignoreTLS=true node your-script-using-notifme.js
+```
+
 ## How to use
 
 - [1. General options](#1-general-options)

--- a/src/providers/email/smtp.js
+++ b/src/providers/email/smtp.js
@@ -7,7 +7,7 @@ export default class EmailSmtpProvider {
   id: string = 'email-smtp-provider'
   transporter: Object
 
-  constructor (config: Object) {
+  constructor (config: Object | string) {
     this.transporter = nodemailer.createTransport(config)
   }
 

--- a/src/providers/notificationCatcherProvider.js
+++ b/src/providers/notificationCatcherProvider.js
@@ -20,10 +20,13 @@ export default class NotificationCatcherProvider {
 
   constructor (channel: ChannelType) {
     this.id = `${channel}-notificationcatcher-provider`
-    this.provider = new EmailSmtpProvider({
+
+    const options = process.env.NOTIFME_CATCHER_OPTIONS || {
       port: 1025,
       ignoreTLS: true
-    })
+    }
+
+    this.provider = new EmailSmtpProvider(options)
   }
 
   async sendToCatcher (request: EmailRequestType): Promise<string> {


### PR DESCRIPTION
Hi @BDav24! First of all, thanks for this lib, is awesome 😊

### About this PR

It adds the possibility to configure the connection options to the Notification Catcher using the env var `NOTIFME_CATCHER_OPTIONS`. It was straightforward implemented thanks to the option of using an string url on Nodemailer's SMTP transoport: https://nodemailer.com/smtp/.

### Use case

This allowed me to use the Notification Catcher with [docker-compose](https://docs.docker.com/compose/), without the need to install-as-dev and run the Catcher on my node app:

```yaml
version: '3'

services:
  myNodeApi:
    build:
      context: .
    environment:
      - NOTIFME_CATCHER_OPTIONS=smtp://notifier:1025?ignoreTLS=true
    command: ["npm", "run", "dev"]
    ports:
      - 3000:3000
    volumes:
      - ./api:/usr/src/api
      - /usr/src/node_modules
    depends_on:
      - notifier

  notifier:
    image: node:8.11.2-alpine
    command: ["npx", "notification-catcher"]
    ports:
      - 1080:1080
```