### PR TITLE
Add ability to use custom channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,7 +866,35 @@ const smsCheapStrategy = (providers) => async (request) => {
 
 If you would like to see another provider or channel, please [upvote the corresponding issue](https://github.com/notifme/notifme-sdk/issues) (or create one if it does not exist yet).
 
-### 3. Send a notification
+### 3. Custom channels
+
+If you want to have custom channels (and providers) you can add them.
+
+Example:
+
+</p></details>
+<details><summary>Custom channel and provider</summary><p>
+
+```
+new NotifmeSdk({
+  channels: {
+    socket: {
+      multiProviderStrategy: 'fallback',
+      providers: [
+        {
+          type: 'custom',
+          id: 'my-socket-sender',
+          send: async () => {
+            return 'custom-socket-id'
+          }
+        }
+      ]
+    }
+  }
+})
+```
+
+### 4. Send a notification
 
 #### Parameters
 
@@ -1034,7 +1062,7 @@ Examples:
 | Success<br>(when Promise resolves) | `{status: 'success', channels: {sms: {id: 'id-116561976', providerId: 'sms-default-provider'}}}` |
 | Error<br>(here Notification Catcher is not running) | `{status: 'error', channels: {sms: {id: undefined, providerId: 'sms-notificationcatcher-provider'}}, errors: {sms: 'connect ECONNREFUSED 127.0.0.1:1025'}}` |
 
-### 4. In production
+### 5. In production
 
 #### Recommended options
 

--- a/__tests__/custom-channel.js
+++ b/__tests__/custom-channel.js
@@ -1,0 +1,48 @@
+/* @flow */
+/* global jest, test, expect */
+import NotifmeSdk from '../src'
+
+jest.mock('../src/util/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn()
+}))
+
+const request = {
+  socket: {
+    to: 'john@example.com',
+    text: 'Hi John'
+  }
+}
+
+test.only('socket', async () => {
+  let socketCalled = false
+  const sdk = new NotifmeSdk({
+    channels: {
+      socket: {
+        multiProviderStrategy: 'fallback',
+        providers: [
+          {
+            type: 'custom',
+            id: 'my-socket-sender',
+            send: async () => {
+              socketCalled = true
+              return 'custom-socket-id'
+            }
+          }
+        ]
+      }
+    }
+  })
+  const result = await sdk.send(request)
+
+  expect(socketCalled).toBe(true)
+  expect(result).toEqual({
+    status: 'success',
+    channels: {
+      socket: {
+        id: 'custom-socket-id',
+        providerId: 'my-socket-sender'
+      }
+    }
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export const CHANNELS = {
 }
 export type ChannelType = $Keys<typeof CHANNELS>
 
-export type NotificationRequestType = {|
+export type NotificationRequestType = {
   metadata?: {
     id?: string,
     userId?: string
@@ -37,7 +37,7 @@ export type NotificationRequestType = {|
   webpush?: WebpushRequestType,
   slack?: SlackRequestType
   // TODO?: other channels (slack, messenger, skype, telegram, kik, spark...)
-|}
+}
 
 export type NotificationStatusType = {
   status: 'success' | 'error',
@@ -90,7 +90,7 @@ export default class NotifmeSdk {
     const providers = providerFactory(mergedOptions.channels)
     const strategies = strategyProvidersFactory(mergedOptions.channels)
 
-    this.sender = new Sender(Object.keys(CHANNELS), providers, strategies)
+    this.sender = new Sender([...(Object.keys(CHANNELS)), ...(Object.keys(providers))], providers, strategies)
   }
 
   mergeWithDefaultConfig ({channels, ...rest}: OptionsType) {
@@ -100,6 +100,7 @@ export default class NotifmeSdk {
       channels: rest.useNotificationCatcher
         ? NotificationCatcherProvider.getConfig(Object.keys(CHANNELS))
         : {
+          ...channels,
           email: {
             providers: [],
             multiProviderStrategy: 'fallback',

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -39,6 +39,10 @@ export default function factory (channels: ChannelOptionsType): ProvidersType {
 
         case 'slack':
           return slackFactory(config)
+
+        default: {
+          return config
+        }
       }
     })
 


### PR DESCRIPTION
Hi there,
I was using `notifme-sdk` and needed a way to add custom channels. The idea I need to implement is to let users define their own channels/providers. That's why I've not opened a new ticket about a specific channel to be implemented.

To make `notifme-sdk` accept custom channels I've:

- added  a `default` to the providers factory that just [return the config](https://github.com/p16/notifme-sdk/blob/add-custom-channels/src/providers/index.js#L43-L45) (as the other factories do).
- added the custom channels to the [sender channels list](https://github.com/p16/notifme-sdk/blob/add-custom-channels/src/index.js#L93)
- updated the `NotificationRequestType` so that is can accepts also other properties

Let me know if this PR make sense and if there are things you may want to change to make this better/more compatible with the library.

Thanks for your work on this!