### PR TITLE
Support array of email ids for to parameter in email notification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ _New: you can check [notifme-template](https://github.com/notifme/notifme-templa
 notifmeSdk.send({
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     html: '<b>Hello John! How are you?</b>'
   }

--- a/__tests__/providers/email/mailgun.js
+++ b/__tests__/providers/email/mailgun.js
@@ -22,7 +22,7 @@ const sdk = new NotifmeSdk({
 const request = {
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     text: 'Hello John! How are you?'
   }

--- a/__tests__/providers/email/mandrill.js
+++ b/__tests__/providers/email/mandrill.js
@@ -21,7 +21,7 @@ const sdk = new NotifmeSdk({
 const request = {
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     text: 'Hello John! How are you?'
   }
@@ -63,7 +63,7 @@ test('Mandrill success with all parameters.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       replyTo: 'replyto@example.com',
@@ -111,7 +111,7 @@ test('Mandrill success with buffered attachment.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       attachments: [{

--- a/__tests__/providers/email/notificationCatcher.js
+++ b/__tests__/providers/email/notificationCatcher.js
@@ -14,7 +14,7 @@ const sdk = new NotifmeSdk({
 const request = {
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     html: '<b>Hello John! How are you?</b>',
     text: 'Hello John! How are you?',

--- a/__tests__/providers/email/sendgrid.js
+++ b/__tests__/providers/email/sendgrid.js
@@ -21,7 +21,7 @@ const sdk = new NotifmeSdk({
 const request = {
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     text: 'Hello John! How are you?'
   }
@@ -64,7 +64,7 @@ test('Sendgrid success with all parameters.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       replyTo: 'replyto@example.com',
@@ -113,7 +113,7 @@ test('Sendgrid success with buffered attachment.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       attachments: [{

--- a/__tests__/providers/email/sparkpost.js
+++ b/__tests__/providers/email/sparkpost.js
@@ -21,7 +21,7 @@ const sdk = new NotifmeSdk({
 const request = {
   email: {
     from: 'me@example.com',
-    to: 'john@example.com',
+    to: ['john@example.com'],
     subject: 'Hi John',
     text: 'Hello John! How are you?'
   }
@@ -64,7 +64,7 @@ test('Sparkpost success with all parameters.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       replyTo: 'replyto@example.com',
@@ -113,7 +113,7 @@ test('Sparkpost success with buffered attachment.', async () => {
     },
     email: {
       from: 'from@example.com',
-      to: 'to@example.com',
+      to: ['to@example.com'],
       subject: 'Hi John',
       html: '<b>Hello John! How are you?</b>',
       attachments: [{

--- a/src/models/notification-request.js
+++ b/src/models/notification-request.js
@@ -7,7 +7,7 @@ type RequestMetadataType = {
 
 export type EmailRequestType = RequestMetadataType & {
   from: string,
-  to: string,
+  to: string[],
   subject: string,
   cc?: string[],
   bcc?: string[],

--- a/src/providers/email/mailgun.js
+++ b/src/providers/email/mailgun.js
@@ -19,7 +19,7 @@ export default class EmailMailgunProvider {
       request.customize ? (await request.customize(this.id, request)) : request
     const form = new FormData()
     form.append('from', from)
-    form.append('to', to)
+    if (to && to.length > 0) to.forEach((email) => form.append("to", email))
     form.append('subject', subject)
     if (text) form.append('text', text)
     if (html) form.append('html', html)

--- a/src/providers/email/mandrill.js
+++ b/src/providers/email/mandrill.js
@@ -25,7 +25,7 @@ export default class EmailMandrillProvider {
         message: {
           from_email: from,
           to: [
-            { email: to, type: 'to' },
+            ...(to && to.length ? to.map((email) => ({ email, type: "to" })) : []),
             ...(cc && cc.length ? cc.map(email => ({ email, type: 'cc' })) : []),
             ...(bcc && bcc.length ? bcc.map(email => ({ email, type: 'bcc' })) : [])
           ],

--- a/src/providers/email/notificationCatcher.js
+++ b/src/providers/email/notificationCatcher.js
@@ -15,7 +15,7 @@ export default class EmailNotificationCatcherProvider extends NotificationCatche
       subject,
       replyTo,
       headers: {
-        'X-to': `[email] ${to}`
+        "X-to": `[email] ${to}`,
       }
     })
   }

--- a/src/providers/email/sendgrid.js
+++ b/src/providers/email/sendgrid.js
@@ -25,7 +25,7 @@ export default class EmailSendGridProvider {
       },
       body: JSON.stringify({
         personalizations: [{
-          to: [{ email: to }],
+          ...(to && to.length > 0 ? { to: to.map((email) => ({ email })) } : null),
           ...(cc && cc.length > 0 ? { cc: cc.map((email) => ({ email })) } : null),
           ...(bcc && bcc.length > 0 ? { bcc: bcc.map((email) => ({ email })) } : null)
         }],

--- a/src/providers/email/sparkpost.js
+++ b/src/providers/email/sparkpost.js
@@ -43,7 +43,7 @@ export default class EmailSparkPostProvider {
             }))
         },
         recipients: [
-          { address: { email: to } },
+          ...(to || []).map((email) => ({ address: { email, header_to: to } })),
           ...(cc || []).map((email) => ({ address: { email, header_to: to } })),
           ...(bcc || []).map((email) => ({ address: { email, header_to: to } }))
         ],


### PR DESCRIPTION
I found that most of the providers that are integrated in this library supports array of email ids in `to` parameter. 
We have a use case where we need to send a notification to multiple email id's. 

Ref: 

https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html
https://mandrillapp.com/api/docs/messages.html
https://documentation.mailgun.com/en/latest/api-sending.html#sending