### PR TITLE
Support email attachments for catcher

### DIFF
--- a/src/providers/email/notificationCatcher.js
+++ b/src/providers/email/notificationCatcher.js
@@ -5,7 +5,7 @@ import type { EmailRequestType } from '../../models/notification-request'
 
 export default class EmailNotificationCatcherProvider extends NotificationCatcherProvider {
   async send (request: EmailRequestType): Promise<string> {
-    const { to, from, html, text, subject, replyTo } =
+    const { to, from, html, text, subject, replyTo, attachments } =
       request.customize ? (await request.customize(this.id, request)) : request
     return this.sendToCatcher({
       to,
@@ -14,6 +14,7 @@ export default class EmailNotificationCatcherProvider extends NotificationCatche
       text,
       subject,
       replyTo,
+      attachments,
       headers: {
         'X-to': `[email] ${to}`
       }


### PR DESCRIPTION
closes #52

NB: I've noticed another bug with the catcher where only the latest email attachments will be visible, but it's better than nothing and I think most people want to make sure the files are actually sending through correctly anyway.